### PR TITLE
Default port to 9092, ping interval none

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 dydx_full_node:
   host: 127.0.0.1 # fill in the IP address of your full node
   grpc_port: 9090
-  websocket_port: 9091
+  websocket_port: 9092
 use_grpc: true
 use_websocket: false
 stream_options:

--- a/main.py
+++ b/main.py
@@ -259,10 +259,11 @@ async def main(args: dict, cpid_to_market_info: dict[int, dict]):
     elif conf['use_websocket']:
         joined = ",".join([str(x) for x in cpids])
         websocket_port = conf['dydx_full_node']['websocket_port']
-        websocket_addr = f"ws://{host}:{websocket_port}/ws?clobPairIds={joined}"
+        subaccount_ids_joined = ",".join(subaccount_ids)
+        websocket_addr = f"ws://{host}:{websocket_port}/ws?clobPairIds={joined}&subaccountIds={subaccount_ids_joined}"
         # Connect to the websocket and start listening
         # TODO(wliu) add subaccount information
-        async with websockets.connect(websocket_addr) as websocket:
+        async with websockets.connect(websocket_addr, ping_interval=None) as websocket:
             interval = conf['interval_ms']
             tasks = [
                 listen_to_websocket(


### PR DESCRIPTION
Kept getting `websockets.exceptions.ConnectionClosedError: sent 1011 (internal error) keepalive ping timeout; no close frame received`, setting `ping_interval=None` seems to fix). 

Also set default port to 9092 since that was changed in protocol